### PR TITLE
Bump compatibility to v9

### DIFF
--- a/module.json
+++ b/module.json
@@ -4,7 +4,7 @@
 	"description": "Adds a ruler tool that allows you to measure distances taking difficult terrain (provided by the terrain layer module) into account.",
 	"version": "1.5.0",
 	"minimumCoreVersion": "0.8.6",
-	"compatibleCoreVersion": "0.8.9",
+	"compatibleCoreVersion": "9",
 	"authors": [
 		{
 			"name": "Manuel Vögele",


### PR DESCRIPTION
This mod seems to be working fine in Foundry V9, there are also no tickets currently pending on it connected to v9. I suggest updating the compatibleCoreVersion to get rid of the Compatibility Risk warning