### PR TITLE
Translations update from Foundry Hub - Weblate

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -5,7 +5,7 @@
 		"settings": {
 			"defaultToggleState": {
 				"name": "Schalterzustand beim Start",
-				"hint": "Definiert welchen Zustand der Terrain Ruler Schalter beim Start von Foundry haben soll",
+				"hint": "Definiert welchen Zustand der Terrain Ruler-Schalter beim Start von Foundry haben soll.",
 				"choices": {
 					"on": "An",
 					"off": "Aus",

--- a/lang/en.json
+++ b/lang/en.json
@@ -5,7 +5,7 @@
 		"settings": {
 			"defaultToggleState": {
 				"name": "Default Toggle State",
-				"hint": "The state of the terrian ruler toggle after joining the game",
+				"hint": "The state of the terrian ruler toggle after joining the game.",
 				"choices": {
 					"on": "On",
 					"off": "Off",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1,5 +1,17 @@
 {
 	"terrain-ruler": {
-		"terrainRuler": "Mesurer la distance avec un terrain difficile"
+		"terrainRuler": "Mesurer la distance avec un terrain difficile",
+		"keybinding": "Activer Terrain ruler",
+		"settings": {
+			"defaultToggleState": {
+				"name": "État d'activation par défaut",
+				"hint": "L'état de Terrain ruler s'active après avoir rejoint la partie.",
+				"choices": {
+					"on": "Actif",
+					"off": "Inactif",
+					"remember": "Se souvenir du dernier état"
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
Translations update from [Foundry Hub - Weblate](https://weblate.foundryvtt-hub.com) for [Terrain Ruler/main](https://weblate.foundryvtt-hub.com/projects/terrain-ruler/main/).



Current translation status:

![Weblate translation status](https://weblate.foundryvtt-hub.com/widgets/terrain-ruler/-/main/horizontal-auto.svg)