### PR TITLE
Return out from measuring distances if ray coordinates are NaN

### DIFF
--- a/src/measure.js
+++ b/src/measure.js
@@ -34,7 +34,7 @@ function measureDistancesSquare(segments, options) {
 	return segments.map((segment => {
 		const ray = segment.ray
 		// Workaround for https://github.com/foundryvtt/foundryvtt/issues/8370
-		if (ray.B === undefined) {
+		if (ray.B === undefined || Number.isNaN(ray.B.x) || Number.isNaN(ray.B.y)) {
 			return NaN;
 		}
 


### PR DESCRIPTION
Expand the workaround for the Foundry bug where measure distances can sometimes be undefined. After testing, I've seen that, as well as `ray.B` being `undefined` sometimes, it can be defined but contain `NaN` for one of or both of its `x` and `y` fields. These also result in an infinite loop later in the function.

I've expanded the conditions on returning early to include this circumstance. Since adding this fix, I have not seen the freeze at all after more testing.

Fixes #33 (or at least mitigates it)