### PR TITLE
Fixed off-by-one error in diagonal distance.

### DIFF
--- a/src/measure.js
+++ b/src/measure.js
@@ -100,10 +100,7 @@ function measureDistancesSquare(segments, options) {
 					// Diagonal Handling
 					if (isDiagonal) {
 						if (measurementRules.diagonalRule === DiagonalRule.APPROXIMATION) {
-							if (measurementRules.diagonalCostType === DiagonalCostType.MULTIPLICATIVE)
-								noDiagonals += cost;
-							else
-								noDiagonals += 1;
+                                                        noDiagonals += 1;
 
 							// How many second diagonals do we have?
 							const diagonalCost = noDiagonals >> 1; // Integer divison by two

--- a/src/measure.js
+++ b/src/measure.js
@@ -101,7 +101,7 @@ function measureDistancesSquare(segments, options) {
 					if (isDiagonal) {
 						if (measurementRules.diagonalRule === DiagonalRule.APPROXIMATION) {
 							if (measurementRules.diagonalCostType === DiagonalCostType.MULTIPLICATIVE)
-								noDiagonals += (cost - 1);
+								noDiagonals += cost;
 							else
 								noDiagonals += 1;
 

--- a/src/measure.js
+++ b/src/measure.js
@@ -101,7 +101,7 @@ function measureDistancesSquare(segments, options) {
 					if (isDiagonal) {
 						if (measurementRules.diagonalRule === DiagonalRule.APPROXIMATION) {
 							if (measurementRules.diagonalCostType === DiagonalCostType.MULTIPLICATIVE)
-								noDiagonals += cost;
+								noDiagonals += (cost - 1);
 							else
 								noDiagonals += 1;
 


### PR DESCRIPTION
The distance calculation for difficult terrain in dnd5e when using the approximate diagonal rule (alternating 5' then 10', and so on) is too high because of an off-by-one error that increases the number of diagonal parts by one.  

The effect of difficult terrain (with a cost of 2) should be an additional square of movement no matter whether we're measuring diagonally or orthogonally.  The normal terrain distance in grid squares along a diagonal is 0, 1, 3, 4, 6, 7, 9, etc.  In difficult terrain, this should to 0, 2, 5, 7, 10, 12, 15, etc.  Instead, the current code is giving me 0, 3, 6, 9, etc.  The fixed version in this PR behaves as expected.
