### PR TITLE
Update Compute Distance for foundry v11

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -83,6 +83,7 @@ function computeDistance(wrapped, gridSpaces) {
 			s.distance = d;
 			s.text = this._getSegmentLabel(s, totalDistance);
 		}
+		this.totalDistance = totalDistance;
 	}
 	else {
 		wrapped(gridSpaces);


### PR DESCRIPTION
Updated the ComputeDistance function so that the total ruler distance doesn't show as NaN when using the ruler in V11